### PR TITLE
Change admin site's title text

### DIFF
--- a/{{cookiecutter.snake_case_slug}}/backend/{{cookiecutter.snake_case_slug}}/urls.py
+++ b/{{cookiecutter.snake_case_slug}}/backend/{{cookiecutter.snake_case_slug}}/urls.py
@@ -22,3 +22,7 @@ urlpatterns = [
     url(r'^api/v1/', include('home.api.v1.urls')),
     url(r'^admin/', admin.site.urls),
 ]
+
+admin.site.site_header = '{{ cookiecutter.project_name }}'
+admin.site.site_title = '{{ cookiecutter.project_name }} Admin Portal'
+admin.site.index_title = '{{ cookiecutter.project_name }} Admin'


### PR DESCRIPTION
Change the title in `/admin` to use the project name