### PR TITLE
Fix cookiecutter slug

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,5 @@
 {
+    "project_slug": "",
     "project_name": "",
     "snake_case_slug": "{{ cookiecutter.project_slug|lower|replace(' ', '_')|replace('-', '_') }}",
     "dash_case_slug": "{{ cookiecutter.snake_case_slug|replace('_', '-') }}",


### PR DESCRIPTION
Adds `project_slug` empty to the `cookiecutter.json`